### PR TITLE
[docs] Improve explanation of _InnerSourceMetadata generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ To do so, apply the following steps:
 
    * Check if there is a file ```innersource.json``` in the repository and add all keys directly below ```_InnerSourceMetadata```.
 
-   * Query GitHub [weekly participation statistics](https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count) (subset "all") and add it with key `participation` 
+   * Query GitHub for the [weekly commit count](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-the-weekly-commit-count) (subset "all") and add it with key `participation` 
 
-   * Check if there is a file ```CONTRIBUTING.md``` and add it with the key `guidelines`
+   * Check if there is a file ```CONTRIBUTING.md``` in the repository and add it with the key `guidelines`, value `CONTRIBUTING.md`
 
-3. (Optional) Calculate the [Repository Activity Score](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/repository-activity-score.md) to define a meaningful order for the projects. Sort entries by score descending.
+   * (Optional) Calculate the [Repository Activity Score](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/repository-activity-score.md) to define a meaningful order for the projects. Sort entries by score descending. Add it with the key `score`
 
-4. Write the resulting list of projects with all metadata to the file ```repos.json``` to serve all projects it in the portal.
+3. Write the resulting list of projects with all metadata to the file ```repos.json``` to serve all projects in the portal.
 
 With this approach, projects can self-register to the portal by adding the ```inner-source``` topic to their repository and specifying additional metadata inside an ```innersource.json``` file.
 For more information about this file, see [Listing Project in the Project Portal for InnerSource](CONTRIBUTING.md#listing-project-in-the-project-portal-for-innersource)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To do so, apply the following steps:
 
    * Check if there is a file ```innersource.json``` in the repository and add all keys directly below ```_InnerSourceMetadata```.
 
-   * Query GitHub for the [weekly commit count](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-the-weekly-commit-count) (subset "all") and add it with key `participation` 
+   * Query GitHub for the [weekly commit count](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-the-weekly-commit-count) (subset "all") and add it with the key `participation` 
 
    * Check if there is a file ```CONTRIBUTING.md``` in the repository and add it with the key `guidelines`, value `CONTRIBUTING.md`
 


### PR DESCRIPTION
While trying to generate my own `repos.json` and the `_InnerSourceMetadata` for each repo, I noticed a couple of things that were a bit hard to understand.

Here my proposed changes:

- changing the link to the GitHub API to point directly to the [weekly commit count](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-the-weekly-commit-count), as there are multiple similar API calls in that section (initially I picked the wrong one myself)
- keep the `score` documentation as a sub-bullet under `_InnerSourceMetadata`, as that is where it lives in the JSON structure too.
- document which key to use for `score`
- document more clearly how to store the `guidelines` block 
- typo fixes and documentation consistency fixes

Cheers