### PR TITLE
Disable caching for repos.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "scripts": {
     "postinstall": "node postinstall",
-    "start": "http-server . -p8080 -o index.html"
+    "start": "http-server . -p8080 -c-1 -o index.html"
   },
   "devDependencies": {
     "http-server": "^0.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-portal-for-innersource",
-  "description": "Lists all InnerSource projects at SAP in an interactive and easy to use portal",
+  "description": "Lists all InnerSource projects at your company in an interactive and easy to use portal",
   "private": true,
   "version": "0.0.1",
   "scripts": {


### PR DESCRIPTION
When building my own local `repos.json` I was changing this file very frequently.
I noticed that even when restarting the http-server with `npm start`, the modified data from `repos.json` would only be picked up in the browser when I did a hard refresh of the index page in the browser.

To fix this I changed the startup config of http-server to disable caching according to [this docs](https://www.npmjs.com/package/http-server). 

I also removed a mention of SAP in `package.json` as I assumed that this might just be a leftover from open sourcing this project? 