### PR TITLE
Fixing the tiny quote :)

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
     </script>
 
     <script id="language-template" type="text/x-handlebars-template">
-      <div class="language tooltipped" style="{{#if color}}background-color: {{color}};{{/if}}{{#if fontSize}}font-size: {{fontSize}}{{/if}}" data-position="top" data-tooltip="Language: {{language}}">{{languageShort}}</div>`
+      <div class="language tooltipped" style="{{#if color}}background-color: {{color}};{{/if}}{{#if fontSize}}font-size: {{fontSize}}{{/if}}" data-position="top" data-tooltip="Language: {{language}}">{{languageShort}}</div>
     </script>
 
     <script id="details-template" type="text/x-handlebars-template">
@@ -238,7 +238,7 @@
         </div>
         {{/if}}
     </script>
-    
+
     <!-- thirdparty libraries -->
     <script src="lib/handlebars.js"></script>
     <script src="lib/materialize.min.js"></script>


### PR DESCRIPTION
There was a tiny regression introduced by #16 which lead to an extra quotation mark (back-tick actually) shown below the language indicator on the overview page. (see image below)

This PR fixes that tiny quote :)

![the tiny quote](https://user-images.githubusercontent.com/163029/106167064-1e34ec80-618d-11eb-9c1c-2d6fc8315cc6.JPG)
