### PR TITLE
[docs] Point to pattern in book, rather than in repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Project Portal for InnerSource [![REUSE status](https://api.reuse.software/badge/github.com/SAP/project-portal-for-innersource)](https://api.reuse.software/info/github.com/SAP/project-portal-for-innersource)
 
 A reference implementation to list all InnerSource projects of a company in an interactive and easy to use way.
-It can be used as a template for implementing the [InnerSource portal pattern](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/innersource-portal.md) by the [InnerSource Commons community](http://innersourcecommons.org/).
-
+It can be used as a template for implementing the [InnerSource Portal pattern](https://patterns.innersourcecommons.org/p/innersource-portal) by the [InnerSource Commons community](http://innersourcecommons.org/).
 
 ## Demo 
 


### PR DESCRIPTION
Point to pattern in book, rather than in repo.
Also changed capitalization of the pattern name.