### PR TITLE
Adding support for Docker compose for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Default to the current Long Term Support (TLS) Node image
+# Can be overriden via a `docker build` argument at build time
+# e.g.: `docker build --build-arg BASE_IMAGE=node:alpine3.15 -t my-image:latest . 
+ARG BASE_IMAGE=node:lts-alpine
+FROM ${BASE_IMAGE}
+
+# Setup a working directory to copy assets into
+WORKDIR /usr/src/app
+
+# Copy everything into the working directory
+COPY . ./
+
+# Install all packages
+RUN npm install
+
+# Listen on TCP 8080, by default, but can be overridden by a `docker build` 
+# argument at build time
+# e.g.: `docker build --build-arg PORT=3000 -t my-image:latest . 
+ARG PORT=8080
+EXPOSE ${PORT}
+
+# Start server
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ npm start
 
 4. Start developing!
 
+## Running locally via Docker Compose
+
+Presuming you already have [Docker or Docker Desktop installed](https://docs.docker.com/get-docker/), simply:
+
+1. `cd` to the root of this repo
+2. Run `docker compose up`
+
+You can then access the service at http://localhost:8080
+
+### Rebuilding and testing locally via Docker Compose
+
+The first time you run `docker compose up`, it will build the image for you, but if you make code changes in this repo and want to test them, you need to rebuild the Docker image via these steps:
+
+1. If running, stop the server by typing `ctrl-c` in the terminal where it is running
+2. Run `docker compose build`
+3. Type `docker compose up` to relaunch
+
 ## Configuration & Crawling
 
 The repository metadata shown in this portal is read from a static `repos.json` file. This project contains a [repos.json](repos.json) file with mock data for testing and developing purposes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.4'
+
+services:
+  innersource-portal:
+    build:
+      context: .
+    ports:
+      - 8080:8080


### PR DESCRIPTION
This branch adds support for Docker compose so the server can be run and developed locally.

Basic usage instructions were added to `README.md`. Some basic Docker ARGS are added for overriding the base Docker image to use, as well as the port to listen on.

Let me know if there is anything else I can help clarify or improve. One thing that comes to mind as a follow up is to change the Dockerfile and make the `repos.json` file mountable. That would allow the same Dockerfile to be used in any container orchestrator, but I didn't want to overstep my reach (i.e.: I didn't know if you planned on having a separate repo to build/maintain a DockerHub image).