### PR TITLE
Feedback: allow "org/repo" search (use full_name instead of name)

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -535,7 +535,7 @@ function search(sParam) {
 	let oResult = window._globals.allRepos.filter(
 		(repo) =>
 			// name
-			repo.name.toLowerCase().includes(sLowerCaseParam) ||
+			repo.full_name.toLowerCase().includes(sLowerCaseParam) ||
 			// description
 			(repo.description && repo.description.toLowerCase().includes(sLowerCaseParam)) ||
 			// InnerSource metadata


### PR DESCRIPTION
With this small change the search allows for searching org/repo name patterns or just orgs in general